### PR TITLE
prevent npm install warning, fixed package rep url

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,13 @@
     "type": "views-jade",
     "behavior": "overrides `sails generate views-jade`",
     "sailsVersion": "~0.10.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/balderdashy/sails-generate-views-jade.git"
+  },
+  "bugs": {
+    "url": "https://github.com/balderdashy/sails-generate-views-jade/issues"
+  },
+  "homepage": "https://github.com/balderdashy/sails-generate-views-jade"
 }


### PR DESCRIPTION
add rep, bugs, home url on package.

```
npm WARN package.json sails-generate-views-jade@0.10.3 No repository field.
```

make this warning message disappeared